### PR TITLE
fix deprecated system variables

### DIFF
--- a/t/001_mysql_sharding_client.t
+++ b/t/001_mysql_sharding_client.t
@@ -105,7 +105,7 @@ note "Done set up Test::mysqld.";
                 user          => $user,
                 password      => $password,
                 pre_commands  => [
-                    'set SQL_MAX_JOIN_SIZE=1028',
+                    'set MAX_JOIN_SIZE=1028',
                     'insert into table_b set id = 999, user_id = 123',
                 ],
             );
@@ -510,4 +510,3 @@ SQL
 
 
 done_testing;
-


### PR DESCRIPTION
`SQL_MAX_JOIN_SIZE` is deprecated system variable.
use `MAX_JOIN_SIZE` instead.
see: https://dev.mysql.com/doc/refman/5.6/en/mysql-nutshell.html#mysql-nutshell-removals

so error in `t/001_mysql_sharding_client.t`
```console
$ prove t/001_mysql_sharding_client.t
t/001_mysql_sharding_client.t .. 10/?
    #   Failed test 'connect DBD::mysql::db do failed: Unknown system variable 'SQL_MAX_JOIN_SIZE' at /path/to/.plenv/versions/5.20.3/lib/perl5/site_perl/5.20.3/MySQL/Sharding/Client.pm line 141.
    # '
    #   at t/001_mysql_sharding_client.t line 113.

    #   Failed test 'prepare insert OK db1'
    #   at t/001_mysql_sharding_client.t line 124.
    # Looks like you failed 2 tests of 2.

#   Failed test 'pre commands'
#   at t/001_mysql_sharding_client.t line 132.
Can't use an undefined value as a HASH reference at t/001_mysql_sharding_client.t line 125.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 102 just after 14.
t/001_mysql_sharding_client.t .. Dubious, test returned 102 (wstat 26112, 0x6600)
Failed 1/14 subtests

Test Summary Report
-------------------
t/001_mysql_sharding_client.t (Wstat: 26112 Tests: 14 Failed: 1)
  Failed test:  14
  Non-zero exit status: 102
  Parse errors: No plan found in TAP output
Files=1, Tests=14, 22 wallclock secs ( 0.02 usr  0.00 sys +  7.97 cusr  6.61 csys = 14.60 CPU)
Result: FAIL
```